### PR TITLE
Add Unwrap, Is and As methods, to match Go's standard errors package.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -27,6 +27,7 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 )
@@ -40,6 +41,11 @@ type annotatedError struct {
 // Error implements error.
 func (e annotatedError) Error() string {
 	return fmt.Sprintf("%s\n%s", e.curr, e.orig.Error())
+}
+
+// Unwrap returns the original error being annotated. See also As and Is methods.
+func (e annotatedError) Unwrap() error {
+	return e.orig
 }
 
 // annotate must be called from Reason or Annotate only.
@@ -66,4 +72,20 @@ func Annotate(e error, s string, args ...interface{}) error {
 		return nil
 	}
 	return &annotatedError{orig: e, curr: annotate(s, args...)}
+}
+
+// Is reports whether any error in err's "Unwrap" chain matches target.
+//
+// It is exactly as Go's errors.Is method, and is provided to match the
+// functionality.
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}
+
+// As sets the target to the first applicable value in err's "Unwrap" chain.
+//
+// It is exactly as Go's errors.As method, and is provided to match the
+// functionality.
+func As(err error, target interface{}) bool {
+	return errors.As(err, target)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -30,6 +30,10 @@ func ann(e error, r string, args ...interface{}) error {
 	return Annotate(e, r, args...)
 }
 
+type myError string
+
+func (e myError) Error() string { return string(e) }
+
 func TestErrors(t *testing.T) {
 	Convey("Reason works", t, func() {
 		e := rsn("because")
@@ -48,6 +52,15 @@ func TestErrors(t *testing.T) {
 
 		Convey("passes through nil error", func() {
 			So(ann(nil, "you won't see this"), ShouldBeNil)
+		})
+
+		Convey("Is and As work", func() {
+			err := myError("mine")
+			annotated := ann(err, "annotated")
+			So(Is(annotated, err), ShouldBeTrue)
+			var err2 myError
+			So(As(annotated, &err2), ShouldBeTrue)
+			So(err2, ShouldEqual, err)
 		})
 	})
 }


### PR DESCRIPTION
Resolves #6.