### PR TITLE
Trim panic frames conservatively

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -99,6 +99,24 @@ func ReasonPanic(s string, args ...any) {
 	panic(ReasonStack(3, s, args...))
 }
 
+// trimFrames to keep only the portion from panic to the top user main(). If in
+// doubt, keep the frames.
+func trimFrames(frames []runtime.Frame) []runtime.Frame {
+	for i, f := range frames {
+		if f.Function == "runtime.gopanic" {
+			frames = frames[i+1:]
+			break
+		}
+	}
+	for i, f := range frames {
+		if f.Function == "runtime.main" {
+			frames = frames[:i]
+			break
+		}
+	}
+	return frames
+}
+
 // FromPanic converts an intentional panic back to error and annotates it with
 // the panic call stack. Other panics are re-raised. It is intended to be used
 // in defer:
@@ -118,36 +136,28 @@ func FromPanic(p any) error {
 			return err
 		}
 		pc = pc[:n] // use only valid pcs
-		frames := runtime.CallersFrames(pc)
+		framesIter := runtime.CallersFrames(pc)
 
-		foundPanic := false
-		traces := []string{}
+		frames := []runtime.Frame{}
 		for {
-			frame, more := frames.Next()
-			if !foundPanic { // skip to the panic origin
-				if frame.Function == "runtime.gopanic" {
-					foundPanic = true
-				}
-				if !more {
-					break
-				}
-				continue
-			}
-			if frame.Function == "runtime.main" { // above user's main(), stop
-				break
-			}
-			traces = append(traces, fmt.Sprintf("PANIC: %s:%d %s()",
-				frame.File, frame.Line, frame.Function))
+			frame, more := framesIter.Next()
+			frames = append(frames, frame)
 			if !more {
 				break
 			}
 		}
+		frames = trimFrames(frames)
+		// Invert frames in place.
+		for l, h := 0, len(frames)-1; l < h; l, h = l+1, h-1 {
+			frames[l], frames[h] = frames[h], frames[l]
+		}
+		traces := []string{}
+		for _, frame := range frames {
+			traces = append(traces, fmt.Sprintf("PANIC: %s:%d %s()",
+				frame.File, frame.Line, frame.Function))
+		}
 		if len(traces) == 0 { // no panic stack found, defensive code
 			return err
-		}
-		// Invert traces in place.
-		for l, h := 0, len(traces)-1; l < h; l, h = l+1, h-1 {
-			traces[l], traces[h] = traces[h], traces[l]
 		}
 		return &annotatedError{orig: err, curr: strings.Join(traces, "\n")}
 	}

--- a/errors.go
+++ b/errors.go
@@ -151,10 +151,10 @@ func FromPanic(p any) error {
 		for l, h := 0, len(frames)-1; l < h; l, h = l+1, h-1 {
 			frames[l], frames[h] = frames[h], frames[l]
 		}
-		traces := []string{}
-		for _, frame := range frames {
-			traces = append(traces, fmt.Sprintf("PANIC: %s:%d %s()",
-				frame.File, frame.Line, frame.Function))
+		traces := make([]string, len(frames))
+		for i, frame := range frames {
+			traces[i] = fmt.Sprintf("PANIC: %s:%d %s()",
+				frame.File, frame.Line, frame.Function)
 		}
 		if len(traces) == 0 { // no panic stack found, defensive code
 			return err

--- a/errors_test.go
+++ b/errors_test.go
@@ -101,7 +101,7 @@ func TestErrors(t *testing.T) {
 				So(trimFrames(frames), ShouldResemble, frames[2:4])
 			})
 
-			Convey("leave frames when no matches found", func() {
+			Convey("keep the frames when no matches found", func() {
 				So(trimFrames(frames[2:4]), ShouldResemble, frames[2:4])
 			})
 		})

--- a/errors_test.go
+++ b/errors_test.go
@@ -15,6 +15,7 @@
 package errors
 
 import (
+	"runtime"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -59,16 +60,16 @@ func TestErrors(t *testing.T) {
 	Convey("Reason works", t, func() {
 		e := rsn("because")
 		So(e.Error(), ShouldContainSubstring,
-			"errors_test.go:25: github.com/stockparfait/errors.rsn() because")
+			"errors_test.go:26: github.com/stockparfait/errors.rsn() because")
 	})
 
 	Convey("Annotate works", t, func() {
 		Convey("annotates non-nil error", func() {
 			e := ann(rsn("because"), "failed %s", "me")
 			So(e.Error(), ShouldContainSubstring,
-				"errors_test.go:30: github.com/stockparfait/errors.ann() failed me")
+				"errors_test.go:31: github.com/stockparfait/errors.ann() failed me")
 			So(e.Error(), ShouldContainSubstring,
-				"errors_test.go:25: github.com/stockparfait/errors.rsn() because")
+				"errors_test.go:26: github.com/stockparfait/errors.rsn() because")
 		})
 
 		Convey("passes through nil error", func() {
@@ -87,17 +88,35 @@ func TestErrors(t *testing.T) {
 
 	Convey("Panic methods work", t, func() {
 
+		Convey("trimFrames", func() {
+			frames := []runtime.Frame{
+				{Function: "aa"},
+				{Function: "runtime.gopanic"},
+				{Function: "cc"},
+				{Function: "bb"},
+				{Function: "runtime.main"},
+				{Function: "runtime.top"},
+			}
+			Convey("trims the frames when possible", func() {
+				So(trimFrames(frames), ShouldResemble, frames[2:4])
+			})
+
+			Convey("leave frames when no matches found", func() {
+				So(trimFrames(frames[2:4]), ShouldResemble, frames[2:4])
+			})
+		})
+
 		Convey("recover an error panic", func() {
 			err := fnA("error")
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring,
-				"errors_test.go:50: github.com/stockparfait/errors.fnC() error in fnC")
+				"errors_test.go:51: github.com/stockparfait/errors.fnC() error in fnC")
 			So(err.Error(), ShouldContainSubstring,
-				"errors_test.go:39 github.com/stockparfait/errors.fnA()")
+				"errors_test.go:40 github.com/stockparfait/errors.fnA()")
 			So(err.Error(), ShouldContainSubstring,
-				"errors_test.go:44 github.com/stockparfait/errors.fnB()")
+				"errors_test.go:45 github.com/stockparfait/errors.fnB()")
 			So(err.Error(), ShouldContainSubstring,
-				"errors_test.go:50 github.com/stockparfait/errors.fnC()")
+				"errors_test.go:51 github.com/stockparfait/errors.fnC()")
 		})
 
 		Convey("re-raise non-error panic", func() {


### PR DESCRIPTION
Previous code required `runtime.gopanic` to be present in the frame stack. However, this may be fragile if runtime changes or under some unusual circumstances. Instead, trim only when matching frames are found, and otherwise conservatively keep the frames.